### PR TITLE
Security hardening, bug fixes, and refactoring (17 fixes)

### DIFF
--- a/src/main/kotlin/com/six2dez/burp/aiagent/alerts/Alerting.kt
+++ b/src/main/kotlin/com/six2dez/burp/aiagent/alerts/Alerting.kt
@@ -4,9 +4,14 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import java.util.concurrent.TimeUnit
 
 object Alerting {
-    private val client = OkHttpClient()
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(5, TimeUnit.SECONDS)
+        .readTimeout(10, TimeUnit.SECONDS)
+        .writeTimeout(10, TimeUnit.SECONDS)
+        .build()
 
     fun sendWebhook(webhookUrl: String, text: String) {
         val json = """{"text":${escapeJson(text)}}"""
@@ -14,7 +19,17 @@ object Alerting {
             .url(webhookUrl)
             .post(json.toRequestBody("application/json".toMediaType()))
             .build()
-        client.newCall(req).execute().close()
+        try {
+            client.newCall(req).execute().use { response ->
+                if (!response.isSuccessful) {
+                    System.err.println("[Burp AI Agent] Webhook delivery failed: HTTP ${response.code} for $webhookUrl")
+                }
+            }
+        } catch (e: java.io.IOException) {
+            System.err.println("[Burp AI Agent] Webhook delivery failed for $webhookUrl: ${e.message}")
+        } catch (e: Exception) {
+            System.err.println("[Burp AI Agent] Unexpected webhook error for $webhookUrl: ${e::class.simpleName}: ${e.message}")
+        }
     }
 
     fun shutdownClient() {
@@ -22,6 +37,28 @@ object Alerting {
         client.connectionPool.evictAll()
     }
 
-    private fun escapeJson(s: String): String =
-        "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n") + "\""
+    private fun escapeJson(s: String): String {
+        val sb = StringBuilder(s.length + 16)
+        sb.append('"')
+        for (ch in s) {
+            when (ch) {
+                '\\' -> sb.append("\\\\")
+                '"' -> sb.append("\\\"")
+                '\n' -> sb.append("\\n")
+                '\r' -> sb.append("\\r")
+                '\t' -> sb.append("\\t")
+                '\b' -> sb.append("\\b")
+                '\u000C' -> sb.append("\\f")
+                else -> {
+                    if (ch.code < 0x20) {
+                        sb.append("\\u%04x".format(ch.code))
+                    } else {
+                        sb.append(ch)
+                    }
+                }
+            }
+        }
+        sb.append('"')
+        return sb.toString()
+    }
 }

--- a/src/main/kotlin/com/six2dez/burp/aiagent/audit/AuditLogger.kt
+++ b/src/main/kotlin/com/six2dez/burp/aiagent/audit/AuditLogger.kt
@@ -14,7 +14,7 @@ import java.util.zip.ZipOutputStream
 
 class AuditLogger(private val api: MontoyaApi) {
     @Volatile
-    private var enabled: Boolean = true
+    private var enabled: Boolean = false
     private val mapper = JsonMapper.builder()
         .enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
         .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)

--- a/src/main/kotlin/com/six2dez/burp/aiagent/config/Defaults.kt
+++ b/src/main/kotlin/com/six2dez/burp/aiagent/config/Defaults.kt
@@ -10,4 +10,5 @@ object Defaults {
     const val BACKEND_STARTUP_DELAY_MS = 2_000L
     const val DEDUP_WINDOW_MS = 3_600_000L
     const val ACTIVE_SCAN_MAX_QUEUE_SIZE = 2_000
+    const val MCP_VERSION = "0.2.1"
 }

--- a/src/main/kotlin/com/six2dez/burp/aiagent/config/McpSettings.kt
+++ b/src/main/kotlin/com/six2dez/burp/aiagent/config/McpSettings.kt
@@ -19,7 +19,8 @@ data class McpSettings(
     val maxConcurrentRequests: Int,
     val maxBodyBytes: Int,
     val toolToggles: Map<String, Boolean>,
-    val unsafeEnabled: Boolean
+    val unsafeEnabled: Boolean,
+    val hostAnonymizationSalt: String = ""
 ) {
     companion object {
         private val mapper = JsonMapper.builder()

--- a/src/main/kotlin/com/six2dez/burp/aiagent/mcp/McpStdioBridge.kt
+++ b/src/main/kotlin/com/six2dez/burp/aiagent/mcp/McpStdioBridge.kt
@@ -33,7 +33,7 @@ class McpStdioBridge(private val api: MontoyaApi) {
         val tools = McpToolCatalog.mergeWithDefaults(settings.toolToggles)
         val unsafeTools = McpToolCatalog.unsafeToolIds()
         val limiter = McpRequestLimiter(settings.maxConcurrentRequests)
-        val hostSalt = "mcp-${settings.token.take(12)}"
+        val hostSalt = settings.hostAnonymizationSalt.ifBlank { "mcp-${settings.token.take(12)}" }
         val context = McpToolContext(
             api = api,
             privacyMode = privacyMode,
@@ -48,7 +48,7 @@ class McpStdioBridge(private val api: MontoyaApi) {
         )
 
         val mcpServer = Server(
-            serverInfo = Implementation("burp-ai-agent", "0.1.0"),
+            serverInfo = Implementation("burp-ai-agent", com.six2dez.burp.aiagent.config.Defaults.MCP_VERSION),
             options = ServerOptions(
                 capabilities = ServerCapabilities(
                     tools = ServerCapabilities.Tools(listChanged = false)

--- a/src/main/kotlin/com/six2dez/burp/aiagent/mcp/McpTls.kt
+++ b/src/main/kotlin/com/six2dez/burp/aiagent/mcp/McpTls.kt
@@ -5,6 +5,9 @@ import io.netty.handler.ssl.util.SelfSignedCertificate
 import java.io.File
 import java.io.FileOutputStream
 import java.security.KeyStore
+import java.security.cert.X509Certificate
+
+private const val KEY_ALIAS = "mcp"
 
 data class McpTlsMaterial(
     val keyStore: KeyStore,
@@ -25,31 +28,65 @@ object McpTls {
             generateSelfSigned(keystoreFile, password)
         }
 
-        val keyStore = KeyStore.getInstance("PKCS12")
+        var keyStore = KeyStore.getInstance("PKCS12")
         keystoreFile.inputStream().use { input ->
             keyStore.load(input, password)
         }
 
-        val alias = keyStore.aliases().toList().firstOrNull() ?: "mcp"
+        // Regenerate if existing cert has wrong CN (e.g. old "burp-mcp" instead of "localhost")
+        if (settings.tlsAutoGenerate && needsRegeneration(keyStore)) {
+            keystoreFile.delete()
+            generateSelfSigned(keystoreFile, password)
+            keyStore = KeyStore.getInstance("PKCS12")
+            keystoreFile.inputStream().use { input ->
+                keyStore.load(input, password)
+            }
+        }
+
+        val alias = if (keyStore.containsAlias(KEY_ALIAS)) KEY_ALIAS
+                    else keyStore.aliases().toList().firstOrNull() ?: KEY_ALIAS
         return McpTlsMaterial(keyStore = keyStore, password = password, keyAlias = alias)
     }
 
-    private fun generateSelfSigned(keystoreFile: File, password: CharArray) {
-        keystoreFile.parentFile?.mkdirs()
-        val ssc = SelfSignedCertificate("burp-mcp")
-        val keyStore = KeyStore.getInstance("PKCS12")
-        keyStore.load(null, password)
-        keyStore.setKeyEntry("mcp", ssc.key(), password, arrayOf(ssc.cert()))
-        FileOutputStream(keystoreFile).use { out ->
-            keyStore.store(out, password)
+    private fun needsRegeneration(keyStore: KeyStore): Boolean {
+        return try {
+            val alias = if (keyStore.containsAlias(KEY_ALIAS)) KEY_ALIAS
+                        else keyStore.aliases().toList().firstOrNull() ?: return true
+            val cert = keyStore.getCertificate(alias) as? X509Certificate ?: return true
+            val cn = cert.subjectX500Principal.name
+            // Regenerate if CN is the old "burp-mcp" instead of "localhost"
+            !cn.contains("CN=localhost", ignoreCase = true)
+        } catch (_: Exception) {
+            true
         }
-        cleanupSelfSigned(ssc)
+    }
+
+    private fun generateSelfSigned(keystoreFile: File, password: CharArray) {
+        val parentDir = keystoreFile.parentFile
+        if (parentDir != null && !parentDir.exists()) {
+            if (!parentDir.mkdirs()) {
+                throw IllegalStateException("Failed to create keystore directory: ${parentDir.absolutePath}")
+            }
+        }
+        // Use "localhost" as CN so the certificate matches loopback hostname verification
+        val ssc = SelfSignedCertificate("localhost")
+        try {
+            val keyStore = KeyStore.getInstance("PKCS12")
+            keyStore.load(null, password)
+            keyStore.setKeyEntry(KEY_ALIAS, ssc.key(), password, arrayOf(ssc.cert()))
+            FileOutputStream(keystoreFile).use { out ->
+                keyStore.store(out, password)
+            }
+        } finally {
+            cleanupSelfSigned(ssc)
+        }
     }
 
     private fun cleanupSelfSigned(cert: SelfSignedCertificate) {
         try {
             cert.delete()
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            System.err.println("[Burp AI Agent] Failed to cleanup self-signed cert temp files: ${e.message}")
         }
     }
 }

--- a/src/main/kotlin/com/six2dez/burp/aiagent/mcp/tools/CollaboratorRegistry.kt
+++ b/src/main/kotlin/com/six2dez/burp/aiagent/mcp/tools/CollaboratorRegistry.kt
@@ -4,11 +4,37 @@ import burp.api.montoya.collaborator.CollaboratorClient
 import java.util.concurrent.ConcurrentHashMap
 
 object CollaboratorRegistry {
+    private const val MAX_ENTRIES = 100
     private val clients = ConcurrentHashMap<String, CollaboratorClient>()
+    private val insertionOrder = java.util.concurrent.ConcurrentLinkedDeque<String>()
 
     fun put(key: String, client: CollaboratorClient) {
-        clients[key] = client
+        if (clients.putIfAbsent(key, client) == null) {
+            insertionOrder.addLast(key)
+            evictIfNeeded()
+        } else {
+            clients[key] = client
+            insertionOrder.remove(key)
+            insertionOrder.addLast(key)
+        }
     }
 
     fun get(key: String): CollaboratorClient? = clients[key]
+
+    fun remove(key: String) {
+        clients.remove(key)
+        insertionOrder.remove(key)
+    }
+
+    fun clear() {
+        clients.clear()
+        insertionOrder.clear()
+    }
+
+    private fun evictIfNeeded() {
+        while (clients.size > MAX_ENTRIES) {
+            val oldest = insertionOrder.pollFirst() ?: break
+            clients.remove(oldest)
+        }
+    }
 }

--- a/src/main/kotlin/com/six2dez/burp/aiagent/mcp/tools/McpTools.kt
+++ b/src/main/kotlin/com/six2dez/burp/aiagent/mcp/tools/McpTools.kt
@@ -863,12 +863,7 @@ private fun hasEquivalentIssue(api: MontoyaApi, name: String, baseUrl: String): 
 }
 
 private fun canonicalIssueName(name: String): String {
-    return name
-        .trim()
-        .replace(Regex("^\\[(?:AI(?:\\s+Passive)?)\\]\\s*", RegexOption.IGNORE_CASE), "")
-        .replace(Regex("^\\[(?:AI(?:\\s+Passive)?)\\]\\s*", RegexOption.IGNORE_CASE), "")
-        .trim()
-        .lowercase()
+    return com.six2dez.burp.aiagent.scanner.canonicalIssueName(name)
 }
 
 /**

--- a/src/main/kotlin/com/six2dez/burp/aiagent/scanner/PassiveAiScanner.kt
+++ b/src/main/kotlin/com/six2dez/burp/aiagent/scanner/PassiveAiScanner.kt
@@ -712,12 +712,7 @@ $metadata
     }
 
     private fun canonicalIssueName(name: String): String {
-        return name
-            .trim()
-            .replace(Regex("^\\[(?:AI(?:\\s+Passive)?)\\]\\s*", RegexOption.IGNORE_CASE), "")
-            .replace(Regex("^\\[(?:AI(?:\\s+Passive)?)\\]\\s*", RegexOption.IGNORE_CASE), "")
-            .trim()
-            .lowercase()
+        return com.six2dez.burp.aiagent.scanner.canonicalIssueName(name)
     }
     
     private fun queueToActiveScanner(
@@ -768,7 +763,7 @@ $metadata
         val lowerTitle = title.lowercase()
         return when {
             // Injection vulnerabilities
-            lowerTitle.contains("sql") || lowerTitle.contains("injection") && lowerTitle.contains("database") -> VulnClass.SQLI
+            lowerTitle.contains("sql") || (lowerTitle.contains("injection") && lowerTitle.contains("database")) -> VulnClass.SQLI
             lowerTitle.contains("xss") || lowerTitle.contains("cross-site scripting") || lowerTitle.contains("script injection") -> VulnClass.XSS_REFLECTED
             lowerTitle.contains("lfi") || lowerTitle.contains("local file") || lowerTitle.contains("file inclusion") -> VulnClass.LFI
             lowerTitle.contains("path traversal") || lowerTitle.contains("directory traversal") -> VulnClass.PATH_TRAVERSAL
@@ -793,7 +788,7 @@ $metadata
 
             // Authentication/Authorization (NEW)
             lowerTitle.contains("account takeover") || lowerTitle.contains("ato") || lowerTitle.contains("password reset") -> VulnClass.ACCOUNT_TAKEOVER
-            lowerTitle.contains("oauth") || lowerTitle.contains("sso") && lowerTitle.contains("bypass") -> VulnClass.OAUTH_MISCONFIGURATION
+            lowerTitle.contains("oauth") || (lowerTitle.contains("sso") && lowerTitle.contains("bypass")) -> VulnClass.OAUTH_MISCONFIGURATION
             lowerTitle.contains("2fa") || lowerTitle.contains("mfa") || lowerTitle.contains("two-factor") -> VulnClass.MFA_BYPASS
             lowerTitle.contains("jwt") || lowerTitle.contains("json web token") -> VulnClass.JWT_WEAKNESS
             lowerTitle.contains("csrf") || lowerTitle.contains("cross-site request forgery") -> VulnClass.CSRF
@@ -807,8 +802,8 @@ $metadata
             // Cache attacks (NEW)
             lowerTitle.contains("cache poison") -> VulnClass.CACHE_POISONING
             lowerTitle.contains("cache deception") -> VulnClass.CACHE_DECEPTION
-            lowerTitle.contains("request smuggling") || lowerTitle.contains("cl.te") || lowerTitle.contains("transfer-encoding") && lowerTitle.contains("content-length") -> VulnClass.REQUEST_SMUGGLING
-            lowerTitle.contains("file upload") || lowerTitle.contains("unrestricted upload") || lowerTitle.contains("upload") && lowerTitle.contains("executable") -> VulnClass.UNRESTRICTED_FILE_UPLOAD
+            lowerTitle.contains("request smuggling") || lowerTitle.contains("cl.te") || (lowerTitle.contains("transfer-encoding") && lowerTitle.contains("content-length")) -> VulnClass.REQUEST_SMUGGLING
+            lowerTitle.contains("file upload") || lowerTitle.contains("unrestricted upload") || (lowerTitle.contains("upload") && lowerTitle.contains("executable")) -> VulnClass.UNRESTRICTED_FILE_UPLOAD
 
             // Information disclosure (NEW)
             lowerTitle.contains("source map") || lowerTitle.contains("sourcemap") -> VulnClass.SOURCEMAP_DISCLOSURE
@@ -818,11 +813,11 @@ $metadata
             lowerTitle.contains("stack trace") || lowerTitle.contains("error leak") -> VulnClass.STACK_TRACE_EXPOSURE
 
             // Cloud/Infrastructure (NEW)
-            lowerTitle.contains("s3") || lowerTitle.contains("bucket") && lowerTitle.contains("public") -> VulnClass.S3_MISCONFIGURATION
+            lowerTitle.contains("s3") || (lowerTitle.contains("bucket") && lowerTitle.contains("public")) -> VulnClass.S3_MISCONFIGURATION
             lowerTitle.contains("subdomain takeover") || lowerTitle.contains("dangling") -> VulnClass.SUBDOMAIN_TAKEOVER
 
             // Business logic (NEW)
-            lowerTitle.contains("price") || lowerTitle.contains("quantity") && lowerTitle.contains("manipulation") -> VulnClass.PRICE_MANIPULATION
+            (lowerTitle.contains("price") || lowerTitle.contains("quantity")) && lowerTitle.contains("manipulation") -> VulnClass.PRICE_MANIPULATION
             lowerTitle.contains("race condition") || lowerTitle.contains("toctou") -> VulnClass.RACE_CONDITION_TOCTOU
 
             // API security (NEW)
@@ -1195,30 +1190,6 @@ $metadata
                 val key = pair.substring(0, separator)
                 if (sensitiveKey.containsMatchIn(key)) "$key=[REDACTED]" else pair
             }
-        }
-    }
-
-    private fun buildMetadataSection(backendInfo: AgentSupervisor.BackendInfo?, scanType: String, confidence: Int): String {
-        return buildString {
-            appendLine("---")
-            appendLine()
-            appendLine("### AI Analysis Metadata")
-            appendLine()
-            if (backendInfo != null) {
-                appendLine("**Backend:** ${backendInfo.displayName}")
-                if (backendInfo.model != null) {
-                    appendLine("**Model:** ${backendInfo.model}")
-                }
-            } else {
-                appendLine("**Backend:** Unknown")
-            }
-            appendLine("**Scan Type:** $scanType")
-            appendLine("**Confidence:** $confidence%")
-            
-            val timestamp = java.time.Instant.now().toString().replace('T', ' ').substringBefore('.')
-            appendLine("**Scan Date:** $timestamp UTC")
-            appendLine()
-            appendLine("---")
         }
     }
 

--- a/src/main/kotlin/com/six2dez/burp/aiagent/scanner/ScannerUtils.kt
+++ b/src/main/kotlin/com/six2dez/burp/aiagent/scanner/ScannerUtils.kt
@@ -1,5 +1,13 @@
 package com.six2dez.burp.aiagent.scanner
 
+fun canonicalIssueName(name: String): String {
+    return name
+        .trim()
+        .replace(Regex("^\\[(?:AI(?:\\s+(?:Passive|Active))?)\\]\\s*", RegexOption.IGNORE_CASE), "")
+        .trim()
+        .lowercase()
+}
+
 object ScannerUtils {
     val HEADER_INJECTION_ALLOWLIST: Set<String> = setOf(
         "host",


### PR DESCRIPTION
## Summary

- **5 security fixes**: Auth on health endpoint for external mode, TLS trust validation with known keystore cert instead of trust-all, temp file cleanup in CliBackend, prompt injection mitigation for large payloads, hostSalt decoupled from MCP token
- **7 bug fixes**: Operator precedence in `mapTitleToVulnClass`, `CollaboratorRegistry` eviction/clear, shared `canonicalIssueName` via `ScannerUtils`, `AtomicReference` for CLI session ID, `Alerting` timeouts and full `escapeJson`, MCP version centralized in `Defaults`
- **5 refactoring items**: Dead code removal (`buildMetadataSection`), `AuditLogger` default aligned with settings, bounded redaction maps (10k cap), backend availability cache key fix, `Thread.sleep` removal

15 files changed, +170 -88 lines.

## Test plan
- [x] `./gradlew clean shadowJar` builds successfully
- [x] `./gradlew test` all tests pass
- [ ] Manual: Load extension in Burp → verify MCP tools respond via Claude Code
- [ ] Manual: Verify health endpoint requires auth when external mode is on

🤖 Generated with [Claude Code](https://claude.com/claude-code)