### PR TITLE
fix(copilot-cli): replace unsupported --quiet with --silent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **Copilot CLI backend**: removed automatic `--quiet` injection from Copilot command building (and strips legacy `--quiet` from saved Copilot extras) because current Copilot CLI versions no longer support that flag. To preserve clean non-interactive output, the backend now uses supported `--silent` by default.
+
 ## [0.9.1] - 2026-07-15
 
 ### Fixed

--- a/src/main/kotlin/com/six2dez/burp/aiagent/backends/cli/CliBackend.kt
+++ b/src/main/kotlin/com/six2dez/burp/aiagent/backends/cli/CliBackend.kt
@@ -864,10 +864,11 @@ internal fun buildTimeoutMessage(
  *
  * Guarantees:
  *  - argv[0] is `base` (the user-supplied executable, defaults to `copilot`).
- *  - `--no-color` and `--quiet` appear BEFORE any auto-injected `-p <prompt>`.
+ *  - `--no-color` and `--silent` appear BEFORE any auto-injected `-p <prompt>`.
  *  - The prompt is appended as `-p <prompt>` only when the user did not already supply `-p` or
  *    `--prompt` in their `extras`; in that case the helper does NOT add a second prompt flag.
- *  - User-supplied `--no-color` and `--quiet` are NOT duplicated (each appears at most once).
+ *  - Legacy `--quiet` is stripped from extras to avoid passing an unsupported Copilot CLI flag.
+ *  - User-supplied `--no-color` and `--silent`/`-s` are NOT duplicated.
  *  - User-supplied extras flow through in their original relative order, after the auto-injected
  *    flags and before the auto-injected `-p` value.
  *
@@ -879,11 +880,11 @@ internal fun buildCopilotCommand(
     prompt: String,
 ): List<String> {
     val base = cmd.firstOrNull() ?: "copilot"
-    val extras = cmd.drop(1)
+    val extras = cmd.drop(1).filterNot { it == "--quiet" }
     val args = mutableListOf<String>()
     args.add(base)
     if (!extras.contains("--no-color")) args.add("--no-color")
-    if (!extras.contains("--quiet")) args.add("--quiet")
+    if (!extras.contains("--silent") && !extras.contains("-s")) args.add("--silent")
     args.addAll(extras)
     if (!extras.contains("-p") && !extras.contains("--prompt")) {
         args.add("-p")

--- a/src/test/kotlin/com/six2dez/burp/aiagent/backends/cli/CopilotCommandBuilderTest.kt
+++ b/src/test/kotlin/com/six2dez/burp/aiagent/backends/cli/CopilotCommandBuilderTest.kt
@@ -10,8 +10,9 @@ import org.junit.jupiter.api.Test
  * dropped into its interactive selection menu and the supervisor's 60-second wall-clock timeout
  * was the only way the call ever returned.
  *
- * The fix builds the argv with `--no-color --quiet -p <prompt>` (idempotent if the user already
- * supplied any of those flags via `BackendLaunchConfig.command`). These tests pin that contract.
+ * The fix builds the argv with `--no-color --silent -p <prompt>` and strips legacy `--quiet`
+ * from extras, because newer Copilot CLI versions no longer support `--quiet`.
+ * These tests pin that contract.
  *
  * Visibility note (per PLAN.md `output` block): `buildCopilotCommand` was extracted from the
  * private inner class `NonInteractiveCliConnection` to a top-level `internal fun` in the same
@@ -19,22 +20,22 @@ import org.junit.jupiter.api.Test
  */
 class CopilotCommandBuilderTest {
     @Test
-    fun bareCopilotCommandGetsNoColorQuietAndPromptFlag() {
+    fun bareCopilotCommandGetsNoColorSilentAndPromptFlag() {
         val argv = buildCopilotCommand(listOf("copilot"), "analyze this")
         assertEquals(
-            listOf("copilot", "--no-color", "--quiet", "-p", "analyze this"),
+            listOf("copilot", "--no-color", "--silent", "-p", "analyze this"),
             argv,
         )
     }
 
     @Test
-    fun noColorAndQuietAppearBeforeDashP() {
+    fun noColorAndSilentAppearBeforeDashP() {
         val argv = buildCopilotCommand(listOf("copilot"), "analyze this")
         val pIndex = argv.indexOf("-p")
         val noColorIndex = argv.indexOf("--no-color")
-        val quietIndex = argv.indexOf("--quiet")
+        val silentIndex = argv.indexOf("--silent")
         assertTrue(noColorIndex in 0 until pIndex, "--no-color must precede -p in $argv")
-        assertTrue(quietIndex in 0 until pIndex, "--quiet must precede -p in $argv")
+        assertTrue(silentIndex in 0 until pIndex, "--silent must precede -p in $argv")
     }
 
     @Test
@@ -44,15 +45,28 @@ class CopilotCommandBuilderTest {
     }
 
     @Test
-    fun userSuppliedQuietIsNotDuplicated() {
+    fun userSuppliedLegacyQuietIsRemoved() {
         val argv = buildCopilotCommand(listOf("copilot", "--quiet"), "x")
-        assertEquals(1, argv.count { it == "--quiet" }, "no duplicate --quiet in $argv")
+        assertFalse(argv.contains("--quiet"), "legacy --quiet must be stripped from $argv")
     }
 
     @Test
     fun userSuppliedNoColorIsNotDuplicated() {
         val argv = buildCopilotCommand(listOf("copilot", "--no-color"), "x")
         assertEquals(1, argv.count { it == "--no-color" }, "no duplicate --no-color in $argv")
+    }
+
+    @Test
+    fun userSuppliedSilentIsNotDuplicated() {
+        val argv = buildCopilotCommand(listOf("copilot", "--silent"), "x")
+        assertEquals(1, argv.count { it == "--silent" }, "no duplicate --silent in $argv")
+    }
+
+    @Test
+    fun userSuppliedShortSilentIsNotDuplicated() {
+        val argv = buildCopilotCommand(listOf("copilot", "-s"), "x")
+        assertEquals(1, argv.count { it == "-s" }, "no duplicate -s in $argv")
+        assertEquals(0, argv.count { it == "--silent" }, "must not auto-add --silent when -s already exists in $argv")
     }
 
     @Test


### PR DESCRIPTION
Removes unsupported --quiet for Copilot CLI, strips legacy --quiet from extras, uses --silent for clean non-interactive output, and updates tests/changelog.